### PR TITLE
bugfix: do not decode html entities

### DIFF
--- a/src/ngx_http_html_sanitize_module.c
+++ b/src/ngx_http_html_sanitize_module.c
@@ -2736,9 +2736,18 @@ ngx_http_html_sanitize_text_visit(ngx_http_request_t *r,
         value = (u_char *) node->v.text.text;
     }
 
+    /*
+     * Do not use text because of html entities
+     */
 
-    text.len = strlen((const char *)value);
-    text.data = value;
+    text.len = node->v.text.original_text.length;
+    text.data = (u_char *) node->v.text.original_text.data;
+
+    dd("tagname:%.*s-text:%.*s origintext-:%.*s", (int) tagname.len,
+        tagname.data,
+        (int) node->v.text.len, node->v.text.data,
+        (int) node->v.text.original_text.length,
+        node->v.text.original_text.data);
 
     ngx_http_html_sanitize_rtrim(&text);
 

--- a/t/010-html-sanitize_html_entities.t
+++ b/t/010-html-sanitize_html_entities.t
@@ -1,0 +1,23 @@
+use Test::Nginx::Socket; # 'no_plan';
+
+repeat_each(2);
+plan tests => repeat_each() * blocks() * 2;
+
+#no_long_string();
+#no_diff;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: do node decode html entities
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_iframe_url_protocol https;
+}
+--- request eval
+"POST /t?element=1&attribute=1
+xxx&quot;&lt;svg/onload=alert(1) onfocus=alert(2)&gt;
+"
+--- response_body: xxx&quot;&lt;svg/onload=alert(1) onfocus=alert(2)&gt;


### PR DESCRIPTION
Now when the input contains the html entities, it's will decode the html entities and it keep the original text also, we should use the original text.